### PR TITLE
Add missing 'l' to docker config file (weuweb02-21tei, week 43)

### DIFF
--- a/md/weuweb02-21tei.md
+++ b/md/weuweb02-21tei.md
@@ -86,7 +86,7 @@ Vi ser avsnitten 1-3 (Introduktion, 15min) och 8-15 (Systemöverblick, 17min) i 
 
 ###### För de som inte lyckats installera en CMS-container än            
 1) Skapa ny projektkatalog       
-2) Ladda ned filen [docker-compose.yml](https://github.com/seetee/docker/blob/master/drupal/docker-compose.ym)
+2) Ladda ned filen [docker-compose.yml](https://github.com/seetee/docker/blob/master/drupal/docker-compose.yml)
 3) Navigera till din projektkatalog och kör följande kommando
 
        docker-compose up -d


### PR DESCRIPTION
The link to docker-compose.yml was missing an 'l' at the end.